### PR TITLE
Fix unit tests to not require scrcpy installed

### DIFF
--- a/test/integration/scrcpy-specs.ts
+++ b/test/integration/scrcpy-specs.ts
@@ -11,6 +11,11 @@ const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 
 describe('Scrcpy Class (integration)', function () {
   const scrcpy = new Scrcpy();
+
+  it('should find path to scrcpy', async function () {
+    const binaryPath = await scrcpy.getScrcpyBinaryPath();
+    expect(binaryPath).to.be.a('string').and.to.include('scrcpy');
+  });
   const testOutputFolder = path.resolve(import.meta.dirname, 'test-output');
   fs.mkdirSync(testOutputFolder, { recursive: true });
 

--- a/test/unit/scrcpy-specs.ts
+++ b/test/unit/scrcpy-specs.ts
@@ -1,22 +1,42 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import Scrcpy from '../../lib/index.js';
+import { SubProcess } from 'teen_process';
 
 use(chaiAsPromised);
 
 describe('Scrcpy Class', function () {
-  const scrcpy = new Scrcpy();
+  const fakeDeps = {
+    which: async () => '/fake/scrcpy',
+    createProcess: () => ({} as SubProcess),
+  };
 
-  it('should find path to scrcpy', async function () {
-    const binaryPath = await scrcpy.getScrcpyBinaryPath();
-    expect(binaryPath).to.be.a('string').and.to.include('scrcpy');
+  it('should cache the binary path after the first lookup', async function () {
+    let callCount = 0;
+    const scrcpy = new Scrcpy({
+      which: async () => { callCount++; return '/fake/scrcpy'; },
+      createProcess: () => ({} as SubProcess),
+    });
+    await scrcpy.getScrcpyBinaryPath();
+    await scrcpy.getScrcpyBinaryPath();
+    expect(callCount).to.equal(1);
   });
 
-  it('should throw error if device udid is not provided', async function () {
+  it('should throw when scrcpy binary is not found', async function () {
+    const scrcpy = new Scrcpy({
+      which: async () => { throw new Error('not found'); },
+      createProcess: () => ({} as SubProcess),
+    });
+    await expect(scrcpy.getScrcpyBinaryPath()).to.eventually.be.rejectedWith('PATH');
+  });
+
+  it('should throw when serial is not provided', async function () {
+    const scrcpy = new Scrcpy(fakeDeps);
     await expect(scrcpy.exec()).to.eventually.be.rejected;
   });
 
-  it('should throw error if path to file is not provided', async function () {
+  it('should throw when pathToFile is not provided', async function () {
+    const scrcpy = new Scrcpy(fakeDeps);
     await expect(scrcpy.exec({ serial: 'emulator-5554' })).to.eventually.be.rejected;
   });
 });


### PR DESCRIPTION
## Summary
- Replace the real-binary `should find path to scrcpy` test with injected-dep tests for path caching and binary-not-found error handling
- Move the real binary check to integration tests where it belongs
- Unit tests now have zero external dependencies and pass cleanly in CI

## Test plan
- [ ] PR check workflow passes on GitHub Actions
- [ ] `npm test` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)