### PR TITLE
Switch npm publish to trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` secret from the release workflow
- npm's trusted publishing uses the OIDC token GitHub Actions already mints (`id-token: write`) to authenticate — no stored secret, no 90-day rotation

## Before merging
- Configure the trusted publisher on npmjs.com: package **Settings** → **Automated Publishing** → add GitHub Actions publisher with owner `gfioretti`, repo `node-scrcpy`, workflow `release.yml`

## Test plan
- [ ] Re-push the release tag after merging and confirm publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)